### PR TITLE
wfix: key value in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,6 @@
     "<all_urls>"
   ],
 
-  "autor": "Conviso"
+  "author": "Conviso"
 
 }


### PR DESCRIPTION
**Motivation:** 
misspelled key in `manifest.json` don't allow the plugin being imported by browser.

**Evidence:**
![image](https://user-images.githubusercontent.com/8931900/158624238-da077135-4cb5-44ba-bc58-63e9a0be7152.png)
